### PR TITLE
ci-cd.yml修正

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,15 +19,19 @@ jobs:
           extensions: mbstring, pdo_mysql, intl
 
       - name: Install Composer dependencies
+        working-directory: src
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
       - name: Copy .env.testing
+        working-directory: src
         run: cp .env.testing.example .env.testing
 
       - name: Generate application key
+        working-directory: src
         run: php artisan key:generate --env=testing
 
       - name: Run tests
+        working-directory: src
         run: php artisan test --env=testing
 
       - name: Notify Slack on test failure


### PR DESCRIPTION
GitHub Actionsが失敗したためci-cd.ymlファイルを修正

原因:
エラーログに`Composer could not find a composer.json file in /home/runner/work/advanced-mock-project/advanced-mock-project
`とありActionsの作業ディレクトリが advanced-mock-project/advanced-mock-project というパスになっているのに対し、実際の `composer.json がadvanced-mock-project/src`に置かれている為失敗したと考えられる。

修正内容:
working-directory を src/ に設定
GitHub Actions の .github/workflows/ci-cd.yml で、working-directory を明示的に src/ に設定。
