### PR TITLE
ci-cd.yml修正part2

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run tests
         working-directory: src
-        run: php artisan test --env=testing
+        run: php artisan test --testsuite=unit --env=testing
 
       - name: Notify Slack on test failure
         if: failure()


### PR DESCRIPTION
ci-cd.yml修正でGithub Actionsが失敗したため、再度ci-cd.ymlを修正（part2）。

原因:
Run testsでtests/FeatureのExampleTest.phpで`$this->get('/') `でMySQL に接続しようとし、今回のCI/CD構築では、データベースを使用しないテストのためMySQL関連の設定をしていないためエラーになったと考えられる。

修正内容:
tests/Unitは成功しており、今回は簡易テストでCI/CDのフローを構築＆確認することが目的のためci-cd.ymlで`--testsuite=unit `を指定し、Unitテストだけ実行するように修正。
