### PR TITLE
メール認証カスタマイズ

### DIFF
--- a/src/.env.development.example
+++ b/src/.env.development.example
@@ -1,4 +1,4 @@
-APP_NAME=laravel
+APP_NAME=Rese
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/src/app/Providers/AuthServiceProvider.php
+++ b/src/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Auth\Notifications\VerifyEmail as VerifyEmailNotification;
+use Illuminate\Notifications\Messages\MailMessage;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -21,6 +23,13 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        VerifyEmailNotification::toMailUsing(function ($notifiable, $url) {
+            return (new MailMessage)
+                ->subject('【Rese】メール認証のお願い')
+                ->greeting('こんにちは、' . $notifiable->name . 'さん!')
+                ->line('アカウントのセキュリティーを確保するために、メールアドレスの認証を完了してください。')
+                ->action('メール認証を完了する', $url)
+                ->line('このメールに心当たりがない場合は、このまま無視してください。');
+        });
     }
 }

--- a/src/public/css/auth/thanks.css
+++ b/src/public/css/auth/thanks.css
@@ -27,15 +27,17 @@
     border-radius: 0.4vw;
     font-size: 1.2vw;
     padding: 0.6vw 0.9vw;
-    margin-top: 3vw;
+    margin: 3vw 0;
 }
 
 .thanks__button:hover {
     background-color: #305cff;
 }
 
-.modal-menu__close {
-    left: 5vw;
+.thanks__indication {
+    line-height: 1.5;
+    font-size: 1vw;
+    color: red;
 }
 
 @media screen and (max-width: 768px) {
@@ -60,5 +62,9 @@
         font-size: 2.5vw;
         padding: 1.2vw 1.8vw;
         margin-top: 6vw;
+    }
+
+    .thanks__indication {
+        font-size: 2vw;
     }
 }

--- a/src/resources/views/auth/thanks.blade.php
+++ b/src/resources/views/auth/thanks.blade.php
@@ -16,6 +16,7 @@
         <div class="thanks__wrapper">
             <p class="thanks__message">会員登録ありがとうございます</p>
             <a class="thanks__button" href="/login">ログインする</a>
+            <p class="thanks__indication">*登録したメールアドレスを確認するために、送信されたリンクをクリックしてください。</p>
         </div>
     </div>
 </main>


### PR DESCRIPTION
### 概要
Laravel 10 + Fortify のデフォルトのメール認証通知をカスタマイズしました。  
これにより、認証メールの件名・本文・ボタンのテキストを自由に変更できるようになります。

---

### 修正内容
1. **`AuthServiceProvider.php` に `VerifyEmail::toMailUsing()` を追加**
   - メール認証の通知をカスタマイズし、デフォルトの通知を上書き。
   
2. **メールのデザイン・文言を変更**
   - 件名を `"【重要】メール認証のお願い"` に変更。
   - ユーザー名 (`$notifiable->name`) を挿入し、親しみのあるメッセージに修正。
   - 「このメールに心当たりがない場合は無視してください。」の文を追加。
   - 認証ボタンのテキストを `"メール認証を完了する"` に変更。

3. **`php artisan config:clear` を実行**
   - 設定キャッシュをクリアし、新しい通知が適用されるようにした。

---

### 修正前の問題
- Fortify のデフォルトのメール認証通知は英語であり、ユーザー向けのカスタマイズができていなかった。
- 事務的な文面で、ユーザーにとってわかりやすくない内容だった。
- メールに `ユーザー名` が含まれておらず、よりフレンドリーな表現にする必要があった。

---

### 修正後の動作確認
- **新規ユーザー登録後に送信されるメールがカスタマイズされたか確認。**
- **ボタン (`メール認証を完了する`) をクリックすると正しく認証が完了するか確認。**
- **`php artisan config:clear` 実行後も正常に適用されるかチェック。**

---

### 影響範囲
- **ユーザー登録後の認証メール通知**
- **Fortify のメール通知機能 (`VerifyEmail` のオーバーライド)**

---