### PR TITLE
コンテナ起動プロセス修正part2

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 
+echo "Checking for composer dependencies..."
+if [ ! -d "vendor" ]; then
+    echo "Vendor directory not found. Running composer install..."
+    composer install --no-interaction --prefer-dist --optimize-autoloader
+else
+    echo "Vendor directory exists. Skipping composer install."
+fi
+
 echo "Waiting for database connection..."
 /usr/local/bin/wait-for-it.sh mysql:3306 --timeout=30 --strict -- echo "Database is up"
 


### PR DESCRIPTION
コンテナ起動プロセス修正でdocker-entrypoint.shを追加したが、`composer install`の実行を定義しておらず`docker-compose up -d --build`後、Laravel の初期化自動処理（例: `php artisan migrate` や `php artisan migrate --seed`）を実行する前に、依存関係（vendor ディレクトリ）が存在しなかった為エラーになってしまった。

コンテナが起動したら、まず`composer install`するようdocker-entrypoint.sh を修正

