### PR TITLE
コンテナ起動プロセスpart4

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -15,6 +15,9 @@ if [ ! -f ".env" ]; then
     php artisan key:generate
 fi
 
+echo "Creating storage symbolic link..."
+php artisan storage:link
+
 echo "Waiting for database connection..."
 /usr/local/bin/wait-for-it.sh mysql:3306 --timeout=30 --strict -- echo "Database is up"
 


### PR DESCRIPTION
コンテナ起動プロセスpart3にて、ストレージリンク作成スクリプトの記述をしていなかったため、docker-entrypoint.shに追加。